### PR TITLE
Removes unrequired load path manipulation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-$:.unshift File.expand_path('..', __FILE__)
-$:.unshift File.expand_path('../../lib', __FILE__)
-
 ENV['BC_AUTH_SERVICE'] = 'https://example.com'
 
 require 'simplecov'


### PR DESCRIPTION
:information_desk_person: The extra paths added to `$LOAD_PATH` aren't required.

(:wave:)
