### PR TITLE
Add MRI Ruby version 2.1(.x) to Travis CI build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
 rvm:
+  - ruby-head
+  - 2.1.1
   - 2.0.0
   - 1.9.3
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
:information_desk_person: Test against recent versions of MRI Ruby for :tada: and :moneybag:.
