### PR TITLE
base UID on store hash

### DIFF
--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -16,7 +16,7 @@ module OmniAuth
         token_url: '/oauth2/token'
       }
 
-      uid { access_token.params['user']['id'] }
+      uid { access_token.params['context'] }
 
       info do
         {


### PR DESCRIPTION
Yesterday we had a customer who had trouble connecting their stores to our system. From what we've gathered, Bigcommerce now allows users to manage multiple stores under one username. I believe this means the UID needs to be based on the store context instead of the user id. Please correct me if I'm wrong. Thanks!