### PR TITLE
Added support for "context" parameter to be set dynamically for authoriz...

### DIFF
--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -9,6 +9,8 @@ module OmniAuth
 
       option :scope, "users_basic_information"
 
+      option :authorize_options, [:scope, :context]
+
       option :client_options,
       {
         site: ENV['BC_AUTH_SERVICE'] || 'https://login.bigcommerce.com',
@@ -43,6 +45,14 @@ module OmniAuth
         @raw_info ||= access_token.params
       end
 
+      #Copied from OmniAuth Google OAuth2 (https://github.com/zquestz/omniauth-google-oauth2)
+      def authorize_params
+        super.tap do |params|
+          options[:authorize_options].each do |k|
+            params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Bigcommerce do
-
   subject do
     OmniAuth::Strategies::Bigcommerce.new({})
+  end
+  
+  before do
+    OmniAuth.config.test_mode = true
+  end
+  
+  after do
+    OmniAuth.config.test_mode = false
   end
 
   context 'client options' do
@@ -35,6 +42,17 @@ describe OmniAuth::Strategies::Bigcommerce do
   context 'callback url' do
     it 'should have the correct path' do
       subject.callback_path.should eq('/auth/bigcommerce/callback')
+    end
+  end
+  
+  context 'authorize options' do
+    describe 'context' do
+      it 'should set the context parameter dynamically in the request' do
+        allow(subject).to receive(:request) do
+          double('Request', :params => {'context' => 'stores/abcdefg'}, :cookies => {}, :env => {})
+        end
+        expect(subject.authorize_params['context']).to eq('stores/abcdefg')
+      end
     end
   end
 end


### PR DESCRIPTION
Added support for "context" parameter to be set dynamically for authorize URL.  Otherwise, the authorization request is missing the store context and incorrectly only authorizes to the Bigcommerce user and not the Bigcommerce store.