### PR TITLE
Use modern Rubies, security updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - ruby-head
   - 2.3.0
   - 2.2.4
-  - 2.1.9
+  - 2.1.8
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   - ruby-head
-  - 2.1.1
-  - 2.0.0
-  - 1.9.3
+  - 2.3.0
+  - 2.2.4
+  - 2.1.9
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
-  module Bigcommerce
+  module BigCommerce
     VERSION = "0.2.0"
   end
 end

--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -2,7 +2,7 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
-    class Bigcommerce < OmniAuth::Strategies::OAuth2
+    class BigCommerce < OmniAuth::Strategies::OAuth2
       option :name, "bigcommerce"
 
       option :provider_ignores_state, true
@@ -57,4 +57,4 @@ module OmniAuth
   end
 end
 
-OmniAuth.config.add_camelization 'bigcommerce', 'Bigcommerce'
+OmniAuth.config.add_camelization 'bigcommerce', 'BigCommerce'

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
   gem.version       = OmniAuth::BigCommerce::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_dependency 'omniauth'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.1.1'
   gem.add_development_dependency 'rake', '~> 2.7'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.1.1'
-  gem.add_development_dependency 'rake', '~> 2.7'
-  gem.add_development_dependency 'rspec', '~> 2.7'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/omniauth/bigcommerce/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Tom Allen, Phil Muir, Sasha Gerrand"]
   gem.email         = ["developer@bigcommerce.com"]
-  gem.description   = %q{Official OmniAuth strategy for Bigcommerce.}
-  gem.summary       = %q{Official OmniAuth strategy for Bigcommerce.}
+  gem.description   = %q{Official OmniAuth strategy for BigCommerce.}
+  gem.summary       = %q{Official OmniAuth strategy for BigCommerce.}
   gem.homepage      = "https://github.com/bigcommerce/omniauth-bigcommerce"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "omniauth-bigcommerce"
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 2.1'
-  gem.version       = OmniAuth::Bigcommerce::VERSION
+  gem.version       = OmniAuth::BigCommerce::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1'

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "omniauth-bigcommerce"
   gem.require_paths = ["lib"]
+  gem.required_ruby_version = '>= 2.1'
   gem.version       = OmniAuth::Bigcommerce::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.0'

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe OmniAuth::Strategies::BigCommerce do
+RSpec.describe OmniAuth::Strategies::BigCommerce do
   subject do
     OmniAuth::Strategies::BigCommerce.new({})
   end

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe OmniAuth::Strategies::Bigcommerce do
+describe OmniAuth::Strategies::BigCommerce do
   subject do
-    OmniAuth::Strategies::Bigcommerce.new({})
+    OmniAuth::Strategies::BigCommerce.new({})
   end
   
   before do

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -13,29 +13,31 @@ RSpec.describe OmniAuth::Strategies::BigCommerce do
     OmniAuth.config.test_mode = false
   end
 
-  context 'client options' do
+  context 'options' do
     it 'should have correct name' do
       expect(subject.options.name).to eq('bigcommerce')
     end
 
-    it 'should have correct site' do
-      # env variable set in spec_helper.rb
-      # TODO: change this once we have bigcommerceapp.com url
-      expect(subject.options.client_options.site).to eq('https://example.com')
+    context 'client options' do
+      it 'should have correct site' do
+        # env variable set in spec_helper.rb
+        # TODO: change this once we have bigcommerceapp.com url
+        expect(subject.options.client_options.site).to eq('https://example.com')
+      end
+
+      it 'should have correct authorize url' do
+        expect(subject.options.client_options.authorize_url).to eq('/oauth2/authorize')
+      end
+
+      it 'should have correct token url' do
+        expect(subject.options.client_options.token_url).to eq('/oauth2/token')
+      end
     end
 
-    it 'should have correct authorize url' do
-      expect(subject.options.client_options.authorize_url).to eq('/oauth2/authorize')
-    end
-
-    it 'should have correct token url' do
-      expect(subject.options.client_options.token_url).to eq('/oauth2/token')
-    end
-  end
-
-  context 'oauth2 settings' do
-    it 'should ignore state' do
-      expect(subject.options.provider_ignores_state).to eq true
+    context 'OAuth2 settings' do
+      it 'should ignore state' do
+        expect(subject.options.provider_ignores_state).to eq true
+      end
     end
   end
 

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OmniAuth::Strategies::BigCommerce do
 
   context 'callback url' do
     it 'should have the correct path' do
-      subject.callback_path.should eq('/auth/bigcommerce/callback')
+      expect(subject.callback_path).to eq('/auth/bigcommerce/callback')
     end
   end
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,16 +2,9 @@ ENV['BC_AUTH_SERVICE'] = 'https://example.com'
 
 require 'simplecov'
 SimpleCov.start
-require 'rspec'
-require 'rack/test'
-require 'webmock/rspec'
-require 'omniauth'
 require 'omniauth-bigcommerce'
 
 RSpec.configure do |config|
-  config.include WebMock::API
-  config.include Rack::Test::Methods
-  config.extend  OmniAuth::Test::StrategyMacros, :type => :strategy
   config.color = true
   config.order = :random
   Kernel.srand config.seed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,8 @@ RSpec.configure do |config|
   config.include WebMock::API
   config.include Rack::Test::Methods
   config.extend  OmniAuth::Test::StrategyMacros, :type => :strategy
+  config.color = true
+  config.order = :random
+  Kernel.srand config.seed
 end
 


### PR DESCRIPTION
:information_desk_person: These changes:
* mitigate [CVE-2012-6134](http://www.rubysec.com/advisories/CVE-2012-6134/) :boom: 
* remove outdated version locks on Rake and RSpec :tada: 
* remove support for EOL MRI Ruby versions :gem: 

:wave: @xenph @philipmuir 