### PR TITLE
Updates the gemspec to allow for newer versions of Oauth2 

### DIFF
--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -15,6 +15,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.3.1'.freeze
+    VERSION = '0.3.2.pre'.freeze
   end
 end

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::BigCommerce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'oauth2', '~> 1.3.1'
+  gem.add_dependency 'oauth2', ['>= 1.3.1', '<= 1.4.1']
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.5'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
chore(PBY-615): updates the gemspec to allow for newer versions of Oauth2 gem usage to facilitate newer versions of Faraday as the version of Oauth2 is limited to Faraday to versions below 0.12

* Reviewed the change log for the Oauth2 gem here:
https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md
* Updated to use Oauth 1.4.1 and all specs pass
