### PR TITLE
ANA-1414: Bump oauth2 version to 1.4.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+Changelog for the omniauth-bigcommerce gem.
+
+### Pending release
+
+### 0.3.3
+
+- Upgrade `oauth2` gem to 1.4.4 or above
+
+### 0.3.2
+
+- Upgrade `oauth2` gem to be between 1.3.1 and 1.4.1
+
+### 0.3.1
+
+- Upgrade `oauth2` gem to 1.3.x
+- Upgrade `omniauth-oauth2` gem to >= 1.5
+- Add copyright notices
+- Remove `git` cli dependency from gemspec
+
+### 0.3.0
+
+- Initial public release

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -15,6 +15,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.3.3.pre'.freeze
+    VERSION = '0.3.4.pre'.freeze
   end
 end

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -15,6 +15,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.3.4.pre'.freeze
+    VERSION = '0.3.3.pre'.freeze
   end
 end

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -13,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require File.expand_path('../lib/omniauth/bigcommerce/version', __FILE__)
+require File.expand_path('lib/omniauth/bigcommerce/version', __dir__)
 
 Gem::Specification.new do |gem|
   gem.authors       = ['BigCommerce Engineering']
@@ -29,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::BigCommerce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'oauth2', ['>= 1.4.4']
+  gem.add_dependency 'oauth2', '>= 1.4.4'
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.5'
   gem.add_development_dependency 'rake'

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::BigCommerce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'oauth2', ['>= 1.3.1', '<= 1.4.1']
+  gem.add_dependency 'oauth2', ['>= 1.4.4']
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.5'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The current release of this gem has an outdated version of the `oauth2` gem and is in need of an upgrade. 

There are several important improvements since `oauth 1.4.1` including official Ruby 2.6 support. 

See the `oauth2` [CHANGELOG](https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md) for more details on these updates.
