### PR TITLE
Release 0.3.3

### DIFF
--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -15,6 +15,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.3.3.pre'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
Increase version to 0.3.3. This release includes an upgrade to the oauth2 gem as well as  standardized BigCommerce OSS documentation. See #24 and #23.