### PR TITLE
Ensure oauth2 gem is < 2.0

### DIFF
--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::BigCommerce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'oauth2', '>= 1.4.4'
+  gem.add_dependency 'oauth2', '>= 1.4.4', '< 2'
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.5'
   gem.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Fixes #29 by binding the oauth2 gem to be < 2.0. 