### PR TITLE
BRP-18348: Bump oauth2 to 2.x (GHSA-pp92-crg2-gfv9) and update supported Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,30 +16,24 @@ gem_cache_key: &gem_cache_key
   gem_cache_key: "gem-cache-v2"
 
 executors:
-  ruby_2_7:
+  ruby_3_3:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.7"
-  ruby_3_0:
+        default: "3.3"
+  ruby_3_4:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "3.0"
-  ruby_3_1:
+        default: "3.4"
+  ruby_4_0:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "3.1"
-  ruby_3_2:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.2"
+        default: "4.0"
 
 commands:
   pre-setup:
@@ -108,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_3"
     steps:
       - pre-setup
       - bundle-install:
@@ -119,7 +113,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_3"
     steps:
       - pre-setup
       - bundle-install:
@@ -130,7 +124,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_3"
     steps:
       - pre-setup
       - bundle-install:
@@ -139,47 +133,36 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
+  ruby_3_3:
     jobs:
       - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
+          name: "ruby-3_3-bundle_audit"
+          e: "ruby_3_3"
       - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
+          name: "ruby-3_3-rubocop"
+          e: "ruby_3_3"
       - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
-  ruby_3_0:
+          name: "ruby-3_3-rspec"
+          e: "ruby_3_3"
+  ruby_3_4:
     jobs:
       - bundle-audit:
-          name: "ruby-3_0-bundle_audit"
-          e: "ruby_3_0"
+          name: "ruby-3_4-bundle_audit"
+          e: "ruby_3_4"
       - rubocop:
-          name: "ruby-3_0-rubocop"
-          e: "ruby_3_0"
+          name: "ruby-3_4-rubocop"
+          e: "ruby_3_4"
       - rspec-unit:
-          name: "ruby-3_0-rspec"
-          e: "ruby_3_0"
-  ruby_3_1:
+          name: "ruby-3_4-rspec"
+          e: "ruby_3_4"
+  ruby_4_0:
     jobs:
       - bundle-audit:
-          name: "ruby-3_1-bundle_audit"
-          e: "ruby_3_1"
+          name: "ruby-4_0-bundle_audit"
+          e: "ruby_4_0"
       - rubocop:
-          name: "ruby-3_1-rubocop"
-          e: "ruby_3_1"
+          name: "ruby-4_0-rubocop"
+          e: "ruby_4_0"
       - rspec-unit:
-          name: "ruby-3_1-rspec"
-          e: "ruby_3_1"
-  ruby_3_2:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_2-bundle_audit"
-          e: "ruby_3_2"
-      - rubocop:
-          name: "ruby-3_2-rubocop"
-          e: "ruby_3_2"
-      - rspec-unit:
-          name: "ruby-3_2-rspec"
-          e: "ruby_3_2"
+          name: "ruby-4_0-rspec"
+          e: "ruby_4_0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@ Changelog for the omniauth-bigcommerce gem.
 
 ### Pending release
 
-### 0.6.0
-
 - Upgrade `oauth2` gem to `>= 2.0.22, < 3` to address [GHSA-pp92-crg2-gfv9](https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9) (protocol-relative redirect leaking bearer tokens)
 - Explicitly set `auth_scheme: :request_body` to preserve client-credential behavior across the oauth2 2.x default change to `:basic_auth`
 - Drop support for Ruby < 3.3; supported versions are now Ruby 3.3, 3.4, and 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog for the omniauth-bigcommerce gem.
 
 ### Pending release
 
+### 0.6.0
+
+- Upgrade `oauth2` gem to `>= 2.0.22, < 3` to address [GHSA-pp92-crg2-gfv9](https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9) (protocol-relative redirect leaking bearer tokens)
+- Explicitly set `auth_scheme: :request_body` to preserve client-credential behavior across the oauth2 2.x default change to `:basic_auth`
+- Drop support for Ruby < 3.3; supported versions are now Ruby 3.3, 3.4, and 4.0
+
 ### 0.5.0
 
 - Ensure `oauth2` gem is below 2.0

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -17,6 +17,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.6.0'
+    VERSION = '0.5.1.pre'
   end
 end

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -17,6 +17,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.5.1.pre'
+    VERSION = '0.6.0'
   end
 end

--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -31,7 +31,11 @@ module OmniAuth
       option :client_options,
              site: ENV.fetch('BC_AUTH_SERVICE', 'https://login.bigcommerce.com'),
              authorize_url: '/oauth2/authorize',
-             token_url: '/oauth2/token'
+             token_url: '/oauth2/token',
+             # oauth2 2.x defaults auth_scheme to :basic_auth, which sends the client
+             # credentials in the Authorization header. BigCommerce's token endpoint
+             # expects them in the request body, so preserve the oauth2 1.x behavior.
+             auth_scheme: :request_body
 
       uid { access_token.params['user']['id'] }
 

--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -27,11 +27,11 @@ Gem::Specification.new do |gem|
   gem.files         = Dir['README.md', 'lib/**/*', 'omniauth-bigcommerce.gemspec', 'Gemfile']
   gem.name          = 'omniauth-bigcommerce'
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 3.3'
   gem.version       = OmniAuth::BigCommerce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'oauth2', '>= 1.4.4', '< 2'
+  gem.add_dependency 'oauth2', '>= 2.0.22', '< 3'
   gem.add_dependency 'omniauth'
   gem.add_dependency 'omniauth-oauth2', '>= 1.5'
   gem.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'faraday'
 
 RSpec.describe OmniAuth::Strategies::BigCommerce do
   let(:store_hash) { 'abcdefg' }
@@ -38,6 +39,11 @@ RSpec.describe OmniAuth::Strategies::BigCommerce do
 
       it 'should have correct token url' do
         expect(subject.options.client_options.token_url).to eq('/oauth2/token')
+      end
+
+      it 'should send client credentials in the request body' do
+        # oauth2 2.x defaults to :basic_auth; BigCommerce expects credentials in the body
+        expect(subject.options.client_options.auth_scheme).to eq(:request_body)
       end
     end
 
@@ -78,6 +84,45 @@ RSpec.describe OmniAuth::Strategies::BigCommerce do
       expect(subject.token_params['context']).to eq(context)
       expect(subject.token_params['scope']).to eq(scope)
       expect(subject.token_params['account_uuid']).to eq(account_uuid)
+    end
+  end
+
+  # Regression guard for the oauth2 1.x -> 2.x upgrade: oauth2 2.x changed the
+  # default auth_scheme from :request_body to :basic_auth, which would move the
+  # client credentials from the POST body into a Basic Authorization header.
+  # BigCommerce's token endpoint expects them in the body, so assert the wire
+  # behavior rather than just the option value.
+  describe 'token request credential placement' do
+    subject { OmniAuth::Strategies::BigCommerce.new(nil, 'the-client-id', 'the-secret') }
+
+    let(:captured_request) { {} }
+
+    before do
+      stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('/oauth2/token') do |env|
+          captured_request[:body] = env.request_body
+          captured_request[:authorization] = env.request_headers['Authorization']
+          [200, { 'Content-Type' => 'application/json' }, '{"access_token":"tok"}']
+        end
+      end
+      client = subject.client
+      test_connection = Faraday.new(client.site) do |builder|
+        builder.request :url_encoded
+        builder.adapter :test, stubs
+      end
+      client.instance_variable_set(:@connection, test_connection)
+      allow(subject).to receive(:client).and_return(client)
+
+      subject.client.auth_code.get_token('the-code', redirect_uri: 'https://app.example/callback')
+    end
+
+    it 'sends the client credentials in the request body' do
+      expect(captured_request[:body]).to include('client_id=the-client-id')
+      expect(captured_request[:body]).to include('client_secret=the-secret')
+    end
+
+    it 'does not send the client credentials in a Basic Authorization header' do
+      expect(captured_request[:authorization]).to be_nil
     end
   end
 end

--- a/spec/omniauth/strategies/bigcommerce_spec.rb
+++ b/spec/omniauth/strategies/bigcommerce_spec.rb
@@ -40,11 +40,6 @@ RSpec.describe OmniAuth::Strategies::BigCommerce do
       it 'should have correct token url' do
         expect(subject.options.client_options.token_url).to eq('/oauth2/token')
       end
-
-      it 'should send client credentials in the request body' do
-        # oauth2 2.x defaults to :basic_auth; BigCommerce expects credentials in the body
-        expect(subject.options.client_options.auth_scheme).to eq(:request_body)
-      end
     end
 
     describe 'OAuth2 settings' do


### PR DESCRIPTION
## Summary
- Upgrades `oauth2` from `>= 1.4.4, < 2` to `>= 2.0.22, < 3` to remediate [GHSA-pp92-crg2-gfv9](https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9) (High — protocol-relative redirect leaking the bearer `Authorization` header). There is no 1.x patch, so this requires the oauth2 2.x major bump.
- Pins `auth_scheme: :request_body` to preserve the oauth2 1.x wire behavior. oauth2 2.x changed the default to `:basic_auth`, which would move client credentials into a Basic `Authorization` header; BigCommerce's token endpoint expects them in the request body.
- Drops support for Ruby < 3.3. Supported versions are now Ruby 3.3, 3.4, and 4.0 (gemspec floor, rubocop target, and CI matrix updated to match).
- Bumps gem version to 0.6.0 (breaking for consumers still on oauth2 1.x / older Ruby).

## Testing
- `bundle exec rspec` — 12 examples, 0 failures (added wire-level tests asserting client credentials land in the request body and not in a Basic auth header; verified they fail if `auth_scheme` reverts to the 2.x default).
- `bundle exec rubocop` — no offenses.
- `bundle exec bundler-audit check` — No vulnerabilities found (was High before).

### Testing

https://github.com/user-attachments/assets/25d24412-0c9b-4ab4-a6b1-feda1eedb003

## Notes
- The `auth_scheme` behavior is now regression-tested, but confirming BigCommerce's token endpoint *accepts* body credentials is an external assumption no unit test can cover — worth a sanity check against a sandbox store before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)