### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changelog for the omniauth-bigcommerce gem.
 
-### Pending release
+### 6.0.0
 
 - Upgrade `oauth2` gem to `>= 2.0.22, < 3` to address [GHSA-pp92-crg2-gfv9](https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9) (protocol-relative redirect leaking bearer tokens)
 - Explicitly set `auth_scheme: :request_body` to preserve client-credential behavior across the oauth2 2.x default change to `:basic_auth`

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -17,6 +17,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.5.1.pre'
+    VERSION = '6.0.0'
   end
 end


### PR DESCRIPTION
This change bumps the version to `6.0` for the changes from https://github.com/bigcommerce/omniauth-bigcommerce/pull/39