### PR TITLE
fix: credentials block returns token string, not OAuth2::AccessToken object

### DIFF
--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -47,9 +47,11 @@ module OmniAuth
       end
 
       credentials do
-        {
-          token: access_token
-        }
+        hash = { 'token' => access_token.token }
+        hash['refresh_token'] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash['expires_at'] = access_token.expires_at if access_token.expires?
+        hash['expires'] = access_token.expires?
+        hash
       end
 
       extra do


### PR DESCRIPTION
## Problem

The `credentials` block in `OmniAuth::Strategies::BigCommerce` stores the full `OAuth2::AccessToken` Ruby object under the `token` key:

```ruby
credentials do
  { token: access_token }   # ← OAuth2::AccessToken instance, not the bearer string
end
```

This causes two problems:

1. **Session serialization breaks.** Rack session stores (cookie, Redis) serialize the auth hash to JSON. `OAuth2::AccessToken` doesn't serialize to a plain string — depending on the serializer you get a `TypeError` at login time, or the field silently becomes `{}` / `null`. Any downstream code reading `session[:omniauth_auth]['credentials']['token']` to make an API call gets nothing useful.

2. **Expiry metadata is silently dropped.** The base class `OmniAuth::Strategies::OAuth2` also includes `refresh_token`, `expires_at`, and `expires` fields (see [omniauth-oauth2 source](https://github.com/omniauth/omniauth-oauth2/blob/v1.9.0/lib/omniauth/strategies/oauth2.rb#L50-L55)). This override discards all of them.

## Fix

Match the base class behavior: call `access_token.token` to get the bearer string, and include the standard expiry fields.

```ruby
credentials do
  hash = { 'token' => access_token.token }
  hash['refresh_token'] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
  hash['expires_at'] = access_token.expires_at if access_token.expires?
  hash['expires'] = access_token.expires?
  hash
end
```

## References

- [`OmniAuth::Strategies::OAuth2#credentials` (omniauth-oauth2 v1.9.0 L50–55)](https://github.com/omniauth/omniauth-oauth2/blob/v1.9.0/lib/omniauth/strategies/oauth2.rb#L50-L55) — the base class this strategy extends and should align with