### PR TITLE
fix: callback_url double-prepends script_name in mounted Rack apps

### DIFF
--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -67,8 +67,10 @@ module OmniAuth
 
       # Exclude query string in callback url. This used to be part of omniauth-oauth2, but was
       # removed in 1.4.0: https://github.com/intridea/omniauth-oauth2/pull/70
+      # Note: callback_path already includes script_name (omniauth/strategy.rb#L458), so we
+      # must not prepend script_name again here.
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
 
       # Make sure to pass scope and context through to the authorize call


### PR DESCRIPTION
## Problem

`OmniAuth::Strategy#callback_path` already embeds `script_name` in the path it returns ([omniauth/strategy.rb L458](https://github.com/omniauth/omniauth/blob/v2.1.4/lib/omniauth/strategy.rb#L458)):

```ruby
path ||= "#{script_name}#{path_prefix}/#{name}/callback"
#         ^^^^^^^^^^^^^^ already included
```

The BigCommerce override then prepends `script_name` a second time:

```ruby
def callback_url
  full_host + script_name + callback_path
  #           ^^^^^^^^^^^   ^^^^^^^^^^^^^ already contains script_name
end
```

In any app mounted at a sub-path (e.g. `SCRIPT_NAME=/myapp`), this produces:

```
https://host.com/myapp/myapp/auth/bigcommerce/callback  ← wrong
```

BigCommerce's token endpoint receives this malformed `redirect_uri` and rejects the token exchange with `invalid_grant`.

The existing test misses this because it stubs `script_name` to `''`, making the double-prepend harmless in tests (see [`OmniAuth::Strategy#callback_url` L504–506](https://github.com/omniauth/omniauth/blob/v2.1.4/lib/omniauth/strategy.rb#L504-L506) for the base implementation this override replaces).

## Fix

The override exists only to strip the `query_string` that the base `callback_url` appends. Removing the redundant `script_name` is sufficient:

```ruby
def callback_url
  full_host + callback_path   # callback_path already carries script_name
end
```

## References

- [`OmniAuth::Strategy#callback_path` L453–458](https://github.com/omniauth/omniauth/blob/v2.1.4/lib/omniauth/strategy.rb#L453-L458) — where `script_name` enters the path
- [`OmniAuth::Strategy#callback_url` L504–506](https://github.com/omniauth/omniauth/blob/v2.1.4/lib/omniauth/strategy.rb#L504-L506) — the base method this override replaces