### PR TITLE
fix: tighten omniauth-oauth2 lower bound to >= 1.7.3

### DIFF
--- a/omniauth-bigcommerce.gemspec
+++ b/omniauth-bigcommerce.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'oauth2', '>= 2.0.22', '< 3'
   gem.add_dependency 'omniauth'
-  gem.add_dependency 'omniauth-oauth2', '>= 1.5'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.7.3'
   gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Problem

The gemspec declares:

```ruby
gem.add_dependency 'omniauth-oauth2', '>= 1.5'
```

But `omniauth-oauth2` versions 1.5.0–1.7.2 all pin `oauth2` to `~> 1.1` or `~> 1.4` (both `< 2.0`), which is incompatible with this gem's current `oauth2 '>= 2.0.22', '< 3'` requirement. A downstream consumer whose Bundler resolves to any of those versions gets a hard `VersionConflict` before any code runs:

```
Bundler could not find compatible versions for gem "oauth2":
  In omniauth-bigcommerce: oauth2 >= 2.0.22, < 3
  In omniauth-oauth2 1.7.0: oauth2 ~> 1.4
```

This is masked in this repo because the `Gemfile.lock` already pins `omniauth-oauth2` to 1.9.0, but any project that doesn't have a lockfile pinning it to 1.7.3+ will hit the conflict.

## Fix

`omniauth-oauth2` 1.7.3 was the first release to loosen its `oauth2` constraint to `>= 1.4, < 3`, making `oauth2` 2.x resolvable alongside it. Raising the lower bound to `>= 1.7.3` makes the minimum compatible version explicit.

## References

- [`omniauth-oauth2` release history](https://github.com/omniauth/omniauth-oauth2/blob/main/CHANGELOG.md) — 1.7.3 is where the oauth2 constraint was loosened to `< 3`
- `omniauth-oauth2` gemspec for [1.7.2](https://github.com/omniauth/omniauth-oauth2/blob/v1.7.2/omniauth-oauth2.gemspec#L20) (`oauth2 ~> 1.4`) vs [1.7.3](https://github.com/omniauth/omniauth-oauth2/blob/v1.7.3/omniauth-oauth2.gemspec#L20) (`oauth2 >= 1.4, < 3`)