### PR TITLE
chore: prep 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the omniauth-bigcommerce gem.
 
 ### Pending release
 
+### 0.7.0
+
 - Fix `credentials` block to return the bearer token string (`access_token.token`) rather than the full `OAuth2::AccessToken` object; also restores `refresh_token`, `expires_at`, and `expires` fields that the previous override was silently dropping
 - Fix `callback_url` double-prepending `script_name` in mounted Rack apps — `OmniAuth::Strategy#callback_path` already includes `script_name`, so the override no longer adds it again
 - Tighten `omniauth-oauth2` lower bound to `>= 1.7.3` to prevent a Bundler `VersionConflict` with `oauth2 >= 2.0.22` for consumers that would otherwise resolve to 1.5.0–1.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog for the omniauth-bigcommerce gem.
 
+### Pending release
+
+- Fix `credentials` block to return the bearer token string (`access_token.token`) rather than the full `OAuth2::AccessToken` object; also restores `refresh_token`, `expires_at`, and `expires` fields that the previous override was silently dropping
+- Fix `callback_url` double-prepending `script_name` in mounted Rack apps — `OmniAuth::Strategy#callback_path` already includes `script_name`, so the override no longer adds it again
+- Tighten `omniauth-oauth2` lower bound to `>= 1.7.3` to prevent a Bundler `VersionConflict` with `oauth2 >= 2.0.22` for consumers that would otherwise resolve to 1.5.0–1.7.2
+
 ### 0.6.0
 
 - Upgrade `oauth2` gem to `>= 2.0.22, < 3` to address [GHSA-pp92-crg2-gfv9](https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9) (protocol-relative redirect leaking bearer tokens)

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -17,6 +17,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.6.0'
+    VERSION = '0.7.0.pre'
   end
 end

--- a/lib/omniauth/bigcommerce/version.rb
+++ b/lib/omniauth/bigcommerce/version.rb
@@ -17,6 +17,6 @@
 #
 module OmniAuth
   module BigCommerce
-    VERSION = '0.7.0.pre'
+    VERSION = '0.7.0'
   end
 end


### PR DESCRIPTION
Tracking PR for the 0.7.0 release. Adds changelog entries for the three bug fixes and bumps `VERSION` to `0.7.0`.

Adds release notes for:
- #42 — fix: credentials block returns token string, not OAuth2::AccessToken object
- #43 — fix: callback_url double-prepends script_name in mounted Rack apps
- #44 — fix: tighten omniauth-oauth2 lower bound to >= 1.7.3